### PR TITLE
Add SEO metadata hook and info page enhancements

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
     <title>Somerhaus - Cincinnati's Premier Event Venue</title>
     <meta name="description" content="Create unforgettable memories at Somerhaus, Cincinnati's most enchanting event space. Perfect for weddings, corporate events, and special occasions." />
     <meta name="author" content="Somerhaus" />
+    <link rel="canonical" href="https://somerhaus.space" />
 
     <meta property="og:title" content="Somerhaus - Cincinnati's Premier Event Venue" />
     <meta property="og:description" content="Create unforgettable memories at Somerhaus, Cincinnati's most enchanting event space. Perfect for weddings, corporate events, and special occasions." />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,10 @@ import Rehearsals from "./pages/Rehearsals";
 import Parties from "./pages/Parties";
 import Meetings from "./pages/Meetings";
 import Gallery from "./pages/Gallery";
+import BarPackages from "./pages/BarPackages";
+import Vendors from "./pages/Vendors";
+import LayoutPage from "./pages/Layout";
+import PressPage from "./pages/Press";
 
 const queryClient = new QueryClient();
 
@@ -47,6 +51,10 @@ const App = () => (
           <Route path="/parties" element={<Parties />} />
           <Route path="/meetings" element={<Meetings />} />
           <Route path="/gallery" element={<Gallery />} />
+          <Route path="/bar-packages" element={<BarPackages />} />
+          <Route path="/vendors" element={<Vendors />} />
+          <Route path="/layout" element={<LayoutPage />} />
+          <Route path="/press" element={<PressPage />} />
           <Route path="*" element={<NotFound />} />
         </Routes>
       </TooltipProvider>

--- a/src/hooks/usePageMetadata.ts
+++ b/src/hooks/usePageMetadata.ts
@@ -1,0 +1,41 @@
+import { useEffect } from "react";
+
+export interface PageMetadata {
+  title?: string;
+  description?: string;
+  canonical?: string;
+}
+
+const usePageMetadata = ({ title, description, canonical }: PageMetadata) => {
+  useEffect(() => {
+    if (title) {
+      document.title = title;
+    }
+
+    if (description) {
+      let meta = document.querySelector<HTMLMetaElement>(
+        'meta[name="description"]'
+      );
+      if (!meta) {
+        meta = document.createElement("meta");
+        meta.setAttribute("name", "description");
+        document.head.appendChild(meta);
+      }
+      meta.setAttribute("content", description);
+    }
+
+    if (canonical) {
+      let link = document.querySelector<HTMLLinkElement>(
+        'link[rel="canonical"]'
+      );
+      if (!link) {
+        link = document.createElement("link");
+        link.setAttribute("rel", "canonical");
+        document.head.appendChild(link);
+      }
+      link.setAttribute("href", canonical);
+    }
+  }, [title, description, canonical]);
+};
+
+export default usePageMetadata;

--- a/src/pages/BarPackages.tsx
+++ b/src/pages/BarPackages.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import Header from '@/components/ui/header';
+import { Footerdemo } from '@/components/ui/footer-section';
+import HeroSection from '@/components/shared/HeroSection';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Separator } from '@/components/ui/separator';
+import { Button } from '@/components/ui/button';
+import { ArrowRight } from 'lucide-react';
+import usePageMetadata from '@/hooks/usePageMetadata';
+
+const BarPackages = () => {
+  usePageMetadata({
+    title: 'Bar Packages - Somerhaus',
+    description:
+      'Explore tiered beverage packages and custom drink options to elevate your event.',
+    canonical: 'https://somerhaus.space/bar-packages',
+  });
+  const heroImages = [{
+    src: '/lovable-uploads/31c22bc4-b41f-4ea7-84ca-97efc98eaef1.png',
+    alt: 'Somerhaus bar setup'
+  }];
+  return (
+    <div className="flex flex-col min-h-screen bg-background">
+      <Header />
+      <HeroSection
+        backgroundType="static"
+        backgroundSources={heroImages}
+        title="Bar Packages"
+        subtitle="Simplicity for your busy schedule – our tiered bar packages meet every need. Have something special in mind? We'll make it happen."
+      />
+      <main className="flex-grow">
+        <section className="py-12 md:py-16">
+          <div className="container mx-auto px-4 max-w-3xl">
+            <h2 className="text-3xl md:text-4xl font-header font-semibold mb-6 text-center text-foreground">Choose Your Package</h2>
+            <Card className="mb-8">
+              <CardHeader>
+                <CardTitle>Tier 1 – $45 per guest</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <ul className="list-disc list-inside space-y-2 font-mono">
+                  <li>3 beer selections, 3 wine selections, 1 seltzer</li>
+                  <li>8 spirits: Tito’s Vodka, Bombay Sapphire, Bacardi Rum, Hornitos Tequila, Maker’s Mark, Redemption Rye, Dewar’s Scotch, Jack Daniel’s</li>
+                  <li>Custom Cocktail: Margarita Three Ways</li>
+                  <li>Welcome Champagne toast</li>
+                  <li>Soft drinks, mixers and garnishes</li>
+                  <li>3 hours of service (extra hours $9/guest, max 2)</li>
+                </ul>
+              </CardContent>
+            </Card>
+            <Card className="mb-8">
+              <CardHeader>
+                <CardTitle>Tier 2 – $35 per guest</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <ul className="list-disc list-inside space-y-2 font-mono">
+                  <li>3 beer selections, 3 wine selections</li>
+                  <li>5 spirits: Finlandia Vodka, New Amsterdam Gin, Cruzan Rum, El Jimador Tequila, Kentucky Tavern Bourbon</li>
+                  <li>Soft drinks, mixers and garnishes</li>
+                  <li>3 hours of service (extra hours $7/guest, max 2)</li>
+                </ul>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader>
+                <CardTitle>Tier 3 – $25 per guest</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <ul className="list-disc list-inside space-y-2 font-mono">
+                  <li>3 beer selections, 3 wine selections</li>
+                  <li>Soft drinks included</li>
+                  <li>3 hours of service (extra hours $7/guest, max 2)</li>
+                </ul>
+              </CardContent>
+            </Card>
+          </div>
+        </section>
+        <Separator />
+        <section className="py-12 md:py-16 bg-muted/40">
+          <div className="container mx-auto px-4 text-center">
+            <h2 className="text-3xl md:text-4xl font-header mb-4">Ready to raise a glass?</h2>
+            <p className="text-lg text-muted-foreground mb-8 font-mono">Book Somerhaus and let our bar team craft something unforgettable.</p>
+            <a href="/event-inquiry">
+              <Button size="lg">Plan Your Event <ArrowRight className="ml-2 w-4 h-4" /></Button>
+            </a>
+          </div>
+        </section>
+      </main>
+      <Footerdemo />
+    </div>
+  );
+};
+
+export default BarPackages;

--- a/src/pages/Layout.tsx
+++ b/src/pages/Layout.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import Header from '@/components/ui/header';
+import { Footerdemo } from '@/components/ui/footer-section';
+import HeroSection from '@/components/shared/HeroSection';
+import { Separator } from '@/components/ui/separator';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { ArrowRight } from 'lucide-react';
+import usePageMetadata from '@/hooks/usePageMetadata';
+
+const LayoutPage = () => {
+  usePageMetadata({
+    title: 'Venue Layout - Somerhaus',
+    description:
+      'Get exact room dimensions and included furnishings to plan your perfect event layout.',
+    canonical: 'https://somerhaus.space/layout',
+  });
+  const heroImages = [{ src: '/lovable-uploads/54dee81d-d7ea-49c7-8588-03e5db9ec8bd.png', alt: 'Somerhaus floor layout' }];
+
+  return (
+    <div className="flex flex-col min-h-screen bg-background">
+      <Header />
+      <HeroSection
+        backgroundType="static"
+        backgroundSources={heroImages}
+        title="Venue Layout"
+        subtitle="Our 3,080 sq ft open floor plan is yours to configure. Explore the possibilities and start envisioning your event."
+      />
+      <main className="flex-grow">
+        <section className="py-12 md:py-16">
+          <div className="container mx-auto px-4 max-w-3xl space-y-8">
+            <Card>
+              <CardHeader>
+                <CardTitle>Room Dimensions</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <ul className="list-disc list-inside space-y-2 font-mono">
+                  <li>Main space: approximately 3,080 square feet</li>
+                  <li>Ceiling height: over 20 feet with skylight</li>
+                  <li>Two ADA-compliant restrooms</li>
+                  <li>Caterer-friendly prep kitchen</li>
+                </ul>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader>
+                <CardTitle>Included Furnishings</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <ul className="list-disc list-inside space-y-2 font-mono">
+                  <li>80 wooden cross-back chairs and 70 folding chairs</li>
+                  <li>10 round tables and 6 rectangular tables</li>
+                  <li>4 high-top cocktail tables</li>
+                  <li>Fully furnished lounge vignettes</li>
+                </ul>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader>
+                <CardTitle>Flexible Configurations</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="font-mono">We offer digital floor plans and sample setups for ceremonies, seated dinners, meetings and more. Let us know how you'd like the room arranged and we'll help craft the perfect layout.</p>
+              </CardContent>
+            </Card>
+          </div>
+        </section>
+        <Separator />
+        <section className="py-12 md:py-16 bg-muted/40">
+          <div className="container mx-auto px-4 text-center">
+            <h2 className="text-3xl md:text-4xl font-header mb-4">Visualize your event here</h2>
+            <p className="text-lg text-muted-foreground mb-8 font-mono">Schedule a tour to see how Somerhaus can transform for you.</p>
+            <a href="/event-inquiry">
+              <Button size="lg">Book a Tour <ArrowRight className="ml-2 w-4 h-4" /></Button>
+            </a>
+          </div>
+        </section>
+      </main>
+      <Footerdemo />
+    </div>
+  );
+};
+
+export default LayoutPage;

--- a/src/pages/Press.tsx
+++ b/src/pages/Press.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import Header from '@/components/ui/header';
+import { Footerdemo } from '@/components/ui/footer-section';
+import HeroSection from '@/components/shared/HeroSection';
+import { Separator } from '@/components/ui/separator';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { ArrowRight } from 'lucide-react';
+import usePageMetadata from '@/hooks/usePageMetadata';
+
+const PressPage = () => {
+  usePageMetadata({
+    title: 'Press & Media - Somerhaus',
+    description: 'Browse recent media coverage and get in touch for press inquiries.',
+    canonical: 'https://somerhaus.space/press',
+  });
+  const heroImages = [{ src: '/lovable-uploads/8eb7ab37-08dc-43b9-9f7a-fa74ac9b112d.png', alt: 'Event at Somerhaus' }];
+
+  return (
+    <div className="flex flex-col min-h-screen bg-background">
+      <Header />
+      <HeroSection
+        backgroundType="static"
+        backgroundSources={heroImages}
+        title="Press & Media"
+        subtitle="See what others are saying about Somerhaus and reach out for media inquiries."
+      />
+      <main className="flex-grow">
+        <section className="py-12 md:py-16">
+          <div className="container mx-auto px-4 max-w-3xl space-y-8">
+            <Card>
+              <CardHeader>
+                <CardTitle>Recent Coverage</CardTitle>
+              </CardHeader>
+              <CardContent className="font-mono space-y-2">
+                <p><strong>CityBeat:</strong> "The Dazzling Paper Lanterns Burlesque and Aerial Variety Show at Somerhaus"</p>
+                <p><strong>Cincinnati Business Courier:</strong> "Growing Entertainment Group Opening OTR Event Space"</p>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader>
+                <CardTitle>Media Contact</CardTitle>
+              </CardHeader>
+              <CardContent className="font-mono">
+                <p>Email: <a href="mailto:hello@somerhaus.com" className="text-primary hover:underline">hello@somerhaus.com</a></p>
+                <p>Phone: <a href="tel:+15139021415" className="text-primary hover:underline">(513) 902-1415</a></p>
+              </CardContent>
+            </Card>
+          </div>
+        </section>
+        <Separator />
+        <section className="py-12 md:py-16 bg-muted/40">
+          <div className="container mx-auto px-4 text-center">
+            <h2 className="text-3xl md:text-4xl font-header mb-4">Want to feature Somerhaus?</h2>
+            <p className="text-lg text-muted-foreground mb-8 font-mono">We're happy to provide quotes, imagery and tours for journalists and bloggers.</p>
+            <a href="mailto:hello@somerhaus.com">
+              <Button size="lg">Contact Our Team <ArrowRight className="ml-2 w-4 h-4" /></Button>
+            </a>
+          </div>
+        </section>
+      </main>
+      <Footerdemo />
+    </div>
+  );
+};
+
+export default PressPage;

--- a/src/pages/Vendors.tsx
+++ b/src/pages/Vendors.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import Header from '@/components/ui/header';
+import { Footerdemo } from '@/components/ui/footer-section';
+import HeroSection from '@/components/shared/HeroSection';
+import { Separator } from '@/components/ui/separator';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { ArrowRight } from 'lucide-react';
+import usePageMetadata from '@/hooks/usePageMetadata';
+
+const Vendors = () => {
+  usePageMetadata({
+    title: 'Preferred Vendors - Somerhaus',
+    description:
+      'Contact information for our recommended caterers, photographers and more.',
+    canonical: 'https://somerhaus.space/vendors',
+  });
+  const heroImages = [{ src: '/lovable-uploads/9af23dea-0956-4cc4-a1c8-f2cee31084b2.png', alt: 'Event setup at Somerhaus' }];
+
+  return (
+    <div className="flex flex-col min-h-screen bg-background">
+      <Header />
+      <HeroSection
+        backgroundType="static"
+        backgroundSources={heroImages}
+        title="Preferred Vendors"
+        subtitle="From photographers to catering, we've curated a trusted list of partners to make your planning effortless."
+      />
+      <main className="flex-grow">
+        <section className="py-12 md:py-16">
+          <div className="container mx-auto px-4 max-w-3xl space-y-12">
+            <Card>
+              <CardHeader>
+                <CardTitle>Catering & Specialty</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <ul className="list-disc list-inside space-y-2 font-mono">
+                  <li>Bee’s BBQ – (513) 561-2337</li>
+                  <li>Chef’s Choice Catering – info@chefschoicecatering.com</li>
+                  <li>Crown Restaurant Group</li>
+                  <li>Essen Kitchen – eat@essenkitchen.com</li>
+                  <li>Findlay Market Merchants</li>
+                  <li>Garnish Catering</li>
+                  <li>Jeff Thomas Catering – events@jeffthomascatering.com</li>
+                  <li>Keystone Bar & Grill</li>
+                  <li>Mazunte – (513) 785-0000</li>
+                  <li>Share Cheesebar</li>
+                  <li>Southern Grace Catering – (513) 808-5819</li>
+                  <li>Taglio OTR – info@eattaglio.com</li>
+                  <li>The Rhined – (513) 655-5938</li>
+                  <li>Yee Mama</li>
+                </ul>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader>
+                <CardTitle>Desserts & Bakeries</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <ul className="list-disc list-inside space-y-2 font-mono">
+                  <li>Allez Bakery – (513) 381-6700</li>
+                  <li>Abby Girl Sweets – (513) 335-0898</li>
+                  <li>Brown Bear Bakery – hello@brownbearbakery.com</li>
+                  <li>Cafe Mochiko – (513) 559-1000</li>
+                  <li>Ilan’s Raw Chocolate</li>
+                  <li>North South Baking Company – kate@northsouthbaking.com</li>
+                  <li>Sixteen Bricks Bakery – (513) 873-1426</li>
+                  <li>Mae’s Cookie Co. – (256) 520-7763</li>
+                </ul>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader>
+                <CardTitle>Coffee Service</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <ul className="list-disc list-inside space-y-2 font-mono">
+                  <li>Deeper Roots Coffee</li>
+                  <li>Yield Coffee Roasters</li>
+                </ul>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader>
+                <CardTitle>Photographers</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <ul className="list-disc list-inside space-y-2 font-mono">
+                  <li>Bird and Rose Photography</li>
+                  <li>Blushing Finch Photography – blushingfinchphoto@gmail.com</li>
+                  <li>Catherine Grace Photography – catievox@gmail.com</li>
+                  <li>Eleven11 Photography – info@eleven11photo.com</li>
+                  <li>J. Carr Photography – jecarr.photos@gmail.com</li>
+                </ul>
+              </CardContent>
+            </Card>
+          </div>
+        </section>
+        <Separator />
+        <section className="py-12 md:py-16 bg-muted/40">
+          <div className="container mx-auto px-4 text-center">
+            <h2 className="text-3xl md:text-4xl font-header mb-4">Have your own vendor in mind?</h2>
+            <p className="text-lg text-muted-foreground mb-8 font-mono">You're welcome to work with anyone you love. A small service fee helps us coordinate logistics seamlessly.</p>
+            <a href="/contact">
+              <Button size="lg">Get in Touch <ArrowRight className="ml-2 w-4 h-4" /></Button>
+            </a>
+          </div>
+        </section>
+      </main>
+      <Footerdemo />
+    </div>
+  );
+};
+
+export default Vendors;


### PR DESCRIPTION
## Summary
- implement `usePageMetadata` hook for dynamic document title and canonical links
- add canonical URL to `index.html`
- apply metadata hook to Bar Packages, Vendors, Layout, and Press pages

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684ca1846dd8832196789a963ab76234