### PR TITLE
Fix inconsistent heading sizes and colors

### DIFF
--- a/src/components/shared/HeroSection.tsx
+++ b/src/components/shared/HeroSection.tsx
@@ -49,7 +49,8 @@ const HeroSection: React.FC<HeroSectionProps> = ({
   buttons = [],
   sectionClassName = "relative w-full h-[90vh] min-h-[600px] overflow-hidden",
   contentContainerClassName = "absolute inset-0 z-20 flex flex-col items-center justify-center text-white text-center px-4",
-  titleClassName = "text-4xl md:text-6xl lg:text-7xl font-header tracking-tight mb-4 text-white",
+  // Standardized hero heading size to match homepage
+  titleClassName = "text-5xl md:text-6xl font-header tracking-tight mb-4 text-white",
   subtitleClassName = "text-lg md:text-xl max-w-2xl mx-auto mb-8 text-white/90 font-body",
   carouselOptions = { loop: true },
   autoplayOptions = { delay: 4000, stopOnInteraction: false, stopOnMouseEnter: false }

--- a/src/components/vendors/VendorsHero.tsx
+++ b/src/components/vendors/VendorsHero.tsx
@@ -14,7 +14,8 @@ const VendorsHero: React.FC = () => {
 
       {/* Content */}
       <div className="relative z-10 flex flex-col items-center justify-center h-full text-center text-white px-4">
-        <h1 className="text-4xl md:text-6xl lg:text-7xl font-header tracking-tight mb-4">Preferred Vendors</h1>
+        {/* Match homepage hero text size */}
+        <h1 className="text-5xl md:text-6xl font-header tracking-tight mb-4">Preferred Vendors</h1>
         <p className="text-lg md:text-xl max-w-2xl mx-auto font-body text-white/90">
           From photographers to catering, we've curated a trusted list of partners to make your planning effortless.
         </p>

--- a/src/index.css
+++ b/src/index.css
@@ -378,4 +378,14 @@
     font-family: "Nebulica", sans-serif;
     font-weight: 200;
   }
+  /* Global heading styles */
+  h1 {
+    @apply text-5xl md:text-6xl font-header tracking-tight mb-4;
+  }
+  h2 {
+    @apply text-3xl md:text-4xl font-header font-semibold mb-6;
+  }
+  h3 {
+    @apply text-2xl md:text-3xl font-header font-semibold mb-4;
+  }
 }

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -102,7 +102,8 @@ const ContactPage = () => {
                     backgroundImage: "url('/photo/space-portrait1-cincinnati-event-space-somerhaus.jpg')"
         }} />
         <div className="relative z-20 container mx-auto px-4 h-full flex flex-col justify-center text-center">
-          <h1 className="text-4xl md:text-6xl lg:text-7xl font-header tracking-tight mb-4 text-white">
+          {/* Standard hero text size */}
+          <h1 className="text-5xl md:text-6xl font-header tracking-tight mb-4 text-white">
             Let's Plan Something Magical Together
           </h1>
           <p className="text-lg md:text-xl max-w-2xl mx-auto mb-8 text-white/90 font-mono">

--- a/src/pages/Gallery.tsx
+++ b/src/pages/Gallery.tsx
@@ -96,7 +96,8 @@ const Gallery = () => {
         <div className="absolute inset-0 bg-black/40" />
         <div className="relative z-10 container mx-auto px-4 text-center text-white">
           <Badge className="mb-4 font-body">Photo Gallery</Badge>
-          <h1 className="text-4xl md:text-6xl lg:text-7xl font-header tracking-tight mb-4">
+          {/* Use consistent hero text size */}
+          <h1 className="text-5xl md:text-6xl font-header tracking-tight mb-4">
             Photo Gallery
           </h1>
           <p className="text-lg md:text-xl max-w-2xl mx-auto mb-8 text-white/90 font-body">


### PR DESCRIPTION
## Summary
- match hero heading sizes across all pages with the homepage
- define global heading typography

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68518cf2f988832180846d082cec0153