### PR TITLE
Add pricing page and bar package calculator

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ import Parties from "./pages/Parties";
 import Meetings from "./pages/Meetings";
 import Gallery from "./pages/Gallery";
 import BarPackages from "./pages/BarPackages";
+import Pricing from "./pages/Pricing";
 import Vendors from "./pages/Vendors";
 import LayoutPage from "./pages/Layout";
 import PressPage from "./pages/Press";
@@ -60,6 +61,7 @@ const App = () => (
           <Route path="/meetings" element={<Meetings />} />
           <Route path="/gallery" element={<Gallery />} />
           <Route path="/bar-packages" element={<BarPackages />} />
+          <Route path="/pricing" element={<Pricing />} />
           <Route path="/vendors" element={<Vendors />} />
           <Route path="/venue-layout" element={<LayoutPage />} />
           <Route path="/press" element={<PressPage />} />

--- a/src/components/bar/BarCostCalculator.tsx
+++ b/src/components/bar/BarCostCalculator.tsx
@@ -1,0 +1,61 @@
+import React, { useState } from 'react';
+import { Input } from '@/components/ui/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { cn } from '@/lib/utils';
+
+const packageRates: Record<string, number> = {
+  tier1: 45,
+  tier2: 35,
+  tier3: 25,
+};
+
+const packageLabels: Record<string, string> = {
+  tier1: 'Tier 1 ($45 per guest)',
+  tier2: 'Tier 2 ($35 per guest)',
+  tier3: 'Tier 3 ($25 per guest)',
+};
+
+const BarCostCalculator: React.FC<{ className?: string }> = ({ className }) => {
+  const [guests, setGuests] = useState(50);
+  const [tier, setTier] = useState<'tier1' | 'tier2' | 'tier3'>('tier1');
+
+  const cost = guests * packageRates[tier];
+
+  return (
+    <section className={cn('py-12 bg-muted/40', className)}>
+      <div className="container mx-auto px-4 max-w-md text-center space-y-4">
+        <h3 className="text-2xl font-header">Estimate Your Bar Cost</h3>
+        <div className="space-y-4">
+          <div>
+            <label className="block text-left text-sm font-medium mb-1" htmlFor="guest-count">Guest Count</label>
+            <Input
+              id="guest-count"
+              type="number"
+              min={1}
+              value={guests}
+              onChange={(e) => setGuests(Number(e.target.value))}
+            />
+          </div>
+          <div>
+            <label className="block text-left text-sm font-medium mb-1">Package</label>
+            <Select value={tier} onValueChange={(val) => setTier(val as 'tier1' | 'tier2' | 'tier3')}>
+              <SelectTrigger className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {Object.entries(packageLabels).map(([key, label]) => (
+                  <SelectItem key={key} value={key} className="cursor-pointer">
+                    {label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <p className="text-lg font-semibold">Estimated Cost: ${cost.toLocaleString()}</p>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default BarCostCalculator;

--- a/src/components/bar/BarFaq.tsx
+++ b/src/components/bar/BarFaq.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion';
+
+const faqs = [
+  {
+    question: 'What bar packages do you offer?',
+    answer: (
+      <div>
+        <p>We provide several tiers to fit different budgets:</p>
+        <ul className="list-disc pl-6 mt-2 space-y-1">
+          <li><strong>Premium Open Bar:</strong> Top-shelf spirits, craft beers and curated wines ($45-55/person)</li>
+          <li><strong>Standard Open Bar:</strong> Quality spirits, domestic and imported beers, house wines ($35-45/person)</li>
+          <li><strong>Beer & Wine:</strong> Selection of beers with house wines ($25-35/person)</li>
+          <li><strong>Consumption Bar:</strong> Pay only for what\'s consumed (minimums apply)</li>
+          <li><strong>Cash Bar:</strong> Guests purchase their own drinks (setup fees apply)</li>
+        </ul>
+        <p className="mt-2">All packages include professional bartenders, standard mixers and non-alcoholic options. Custom packages and signature cocktails are available upon request.</p>
+      </div>
+    ),
+  },
+  {
+    question: 'Can we bring our own alcohol?',
+    answer: 'Yes. Our BYOB option starts at $10 per guest which covers licensed bartenders, mixers, ice, glassware and insurance. Alcohol must be delivered during your rental and removed afterward. Only our staff may serve and all state liquor laws apply.',
+  },
+];
+
+const BarFaq: React.FC = () => (
+  <section className="py-12">
+    <div className="container mx-auto px-4">
+      <h2 className="text-3xl font-header text-center mb-6">Bar Service FAQs</h2>
+      <Accordion type="single" collapsible className="max-w-2xl mx-auto">
+        {faqs.map((faq, i) => (
+          <AccordionItem value={`item-${i}`} key={i}>
+            <AccordionTrigger>{faq.question}</AccordionTrigger>
+            <AccordionContent>{faq.answer}</AccordionContent>
+          </AccordionItem>
+        ))}
+      </Accordion>
+    </div>
+  </section>
+);
+
+export default BarFaq;

--- a/src/pages/BarPackages.tsx
+++ b/src/pages/BarPackages.tsx
@@ -8,6 +8,8 @@ import { Button } from '@/components/ui/button';
 import { ArrowRight } from 'lucide-react';
 import Seo from '@/components/seo/Seo';
 import PricingSection from '@/components/shared/PricingSection';
+import BarCostCalculator from '@/components/bar/BarCostCalculator';
+import BarFaq from '@/components/bar/BarFaq';
 
 const BarPackages = () => {
   return (
@@ -75,6 +77,8 @@ const BarPackages = () => {
             </div>
           }
         />
+        <BarCostCalculator />
+        <BarFaq />
         <Separator />
         <section className="py-12 md:py-16 bg-muted/40">
           <div className="container mx-auto px-4 text-center">

--- a/src/pages/Pricing.tsx
+++ b/src/pages/Pricing.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import Header from '@/components/ui/header';
+import { Footerdemo } from '@/components/ui/footer-section';
+import PricingSection from '@/components/shared/PricingSection';
+import { Button } from '@/components/ui/button';
+import { ArrowRight } from 'lucide-react';
+import Seo from '@/components/seo/Seo';
+
+const Pricing = () => {
+  return (
+    <div className="flex flex-col min-h-screen bg-background">
+      <Seo title="Event Pricing | Somerhaus" description="Transparent venue rental rates for events at Somerhaus" />
+      <Header />
+      <main className="flex-grow">
+        <section className="py-20 text-center bg-gradient-to-b from-orange-50 to-background">
+          <div className="container mx-auto px-4">
+            <h1 className="text-5xl font-header mb-6">Event Pricing</h1>
+            <p className="text-lg text-muted-foreground max-w-2xl mx-auto font-body">
+              Our straightforward packages make budgeting simple. Beverage minimums apply as listed.
+            </p>
+          </div>
+        </section>
+        <PricingSection
+          title="Venue Rental Rates"
+          description="All rentals include tables and chairs for up to 80 guests, basic lighting, sound system, and setup/teardown assistance."
+          packages={[
+            {
+              name: 'Sun–Thu Evening',
+              price: '$1,500',
+              priceSuffix: '+ $500 bar minimum',
+              features: [
+                '5-hour event block',
+                'Tables & chairs for up to 80 guests',
+                'Basic lighting & sound system',
+              ],
+              buttonText: 'Inquire',
+              buttonProps: { variant: 'outline' },
+            },
+            {
+              name: 'Fri–Sat Evening',
+              price: '$3,000',
+              priceSuffix: '+ $1,000 bar minimum',
+              features: [
+                '5-hour event block',
+                'Tables & chairs for up to 80 guests',
+                'Basic lighting & sound system',
+              ],
+              buttonText: 'Inquire',
+              buttonProps: { variant: 'outline' },
+            },
+            {
+              name: 'Corporate Half-Day',
+              price: '$750',
+              priceSuffix: 'Mon–Fri',
+              features: [
+                'Up to 4-hour daytime block',
+                'Tables & chairs arranged for meetings',
+                'AV support & WiFi',
+              ],
+              buttonText: 'Book Now',
+              buttonProps: { variant: 'outline' },
+            },
+            {
+              name: 'Corporate Full-Day',
+              price: '$1,200',
+              priceSuffix: 'Mon–Fri',
+              features: [
+                'Up to 8-hour daytime block',
+                'Tables & chairs arranged for meetings',
+                'AV support & WiFi',
+              ],
+              buttonText: 'Book Now',
+              buttonProps: { variant: 'outline' },
+            },
+            {
+              name: 'Non-Profit Events',
+              price: 'Custom',
+              features: [
+                'Flexible pricing tailored to your organization',
+                'Includes standard amenities',
+              ],
+              buttonText: 'Contact Us',
+              buttonProps: { variant: 'outline' },
+            },
+          ]}
+        />
+        <section className="py-12 text-center">
+          <a href="/event-inquiry">
+            <Button size="lg">Start Planning <ArrowRight className="ml-2 w-4 h-4" /></Button>
+          </a>
+        </section>
+      </main>
+      <Footerdemo />
+    </div>
+  );
+};
+
+export default Pricing;


### PR DESCRIPTION
## Summary
- implement a dedicated **Pricing** page with venue rental rates
- add a cost estimator and FAQ section to **BarPackages**
- wire new components and route in `App.tsx`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68519081043483219a5251b57b4d8951