### PR TITLE
Unify booking CTAs

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Star } from "lucide-react";
-import { TiltCard } from "@/components/ui/tilt-card";
+import { BookNowButton } from "@/components/ui/book-now-button";
 import AvatarGroup from './AvatarGroup';
 
 const Hero = () => {
@@ -45,10 +45,9 @@ const Hero = () => {
           <span>Event Space</span>
         </h1>
 
-        <p className="text-xl text-center mb-6 max-w-2xl font-body font-extralight md:text-lg">
-          Book your tour today and see how our ivy-covered historic venue turns special moments into lasting memories.<br />
-          <span className="italic">*Limited dates available for 2025*</span>
-        </p>
+          <p className="text-xl text-center mb-6 max-w-2xl font-body font-extralight md:text-lg">
+            Book your tour today and see how our ivy-covered historic venue turns special moments into lasting memories.
+          </p>
 
         <div className="flex items-center gap-2 mb-8 font-body">
           <div className="flex">
@@ -67,9 +66,7 @@ const Hero = () => {
       </div>
 
       <div className="absolute left-1/2 transform -translate-x-1/2 bottom-[16%]">
-        <TiltCard href="/event-inquiry" className="group max-h-fit rounded-full bg-black p-2 px-6 shadow-[0_20px_50px_rgba(0,0,0,0.8)] hover:bg-[#D9FF8A]">
-          <span className="text-xl text-white group-hover:text-black font-body">Book Your Tour</span>
-        </TiltCard>
+        <BookNowButton />
       </div>
     </div>
   );

--- a/src/components/bar/BarPackagesHero.tsx
+++ b/src/components/bar/BarPackagesHero.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import HeroSection from '@/components/shared/HeroSection';
-import { TiltCard } from '@/components/ui/tilt-card';
+import { BookNowButton } from '@/components/ui/book-now-button';
 
 const BarPackagesHero: React.FC = () => {
   const heroImages = [
@@ -44,12 +44,7 @@ const BarPackagesHero: React.FC = () => {
 
       {/* CTA */}
       <div className="absolute left-1/2 transform -translate-x-1/2 bottom-[16%] z-30">
-        <TiltCard
-          href="/event-inquiry"
-          className="group max-h-fit rounded-full bg-black p-2 px-6 shadow-[0_20px_50px_rgba(0,0,0,0.8)] hover:bg-[#D9FF8A]"
-        >
-          <span className="text-xl text-white group-hover:text-black font-body">Start Pouring</span>
-        </TiltCard>
+        <BookNowButton />
       </div>
     </div>
   );

--- a/src/components/blocks/feature-section.tsx
+++ b/src/components/blocks/feature-section.tsx
@@ -4,7 +4,7 @@ import React, { useState, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { cn } from "@/lib/utils";
 import { LucideIcon, ChevronDown } from "lucide-react";
-import { TiltCard } from "@/components/ui/tilt-card";
+import { BookNowButton } from "@/components/ui/book-now-button";
 
 interface Feature {
   step: string;
@@ -157,9 +157,7 @@ export function FeatureSteps({
           }}
           viewport={{ once: true }}
         >
-          <TiltCard href="/event-inquiry" className="group max-h-fit rounded-full bg-black p-2 px-6 shadow-[0_10px_25px_rgba(0,0,0,0.4)] hover:bg-[#D9FF8A]">
-            <span className="text-xl text-white group-hover:text-black font-body">Book Your Tour</span>
-          </TiltCard>
+          <BookNowButton className="shadow-[0_10px_25px_rgba(0,0,0,0.4)]" />
         </motion.div>
       </div>
     </div>;

--- a/src/components/corporate/CorporatePricing.tsx
+++ b/src/components/corporate/CorporatePricing.tsx
@@ -23,7 +23,6 @@ const CorporatePricing = () => {
       preFeaturesContent: ( // Use preFeaturesContent for duration
         <p className="text-gray-500 font-body">4 hours</p>
       ),
-      buttonText: "Book This Package",
       buttonProps: { className: "font-body bg-black hover:bg-black/80" }, // Specific style for non-popular
       popular: false, // Map 'isPopular' to 'popular'
       cardClassName: "font-body", // Apply base font
@@ -43,7 +42,6 @@ const CorporatePricing = () => {
       preFeaturesContent: (
         <p className="text-gray-500 font-body">8 hours</p>
       ),
-      buttonText: "Book This Package",
       buttonProps: { className: "font-body" }, // Default style for popular
       popular: true,
       popularText: "Most Popular",
@@ -66,7 +64,6 @@ const CorporatePricing = () => {
       preFeaturesContent: (
         <p className="text-gray-500 font-body">Sunday-Thursday</p>
       ),
-      buttonText: "Book This Package",
       buttonProps: { className: "font-body bg-black hover:bg-black/80" },
       popular: false,
       cardClassName: "font-body",

--- a/src/components/parties/PartiesHero.tsx
+++ b/src/components/parties/PartiesHero.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import HeroSection from '@/components/shared/HeroSection';
-import { TiltCard } from '@/components/ui/tilt-card';
+import { BookNowButton } from '@/components/ui/book-now-button';
 
 const PartiesHero: React.FC = () => {
   const heroImages = [
@@ -44,12 +44,7 @@ const PartiesHero: React.FC = () => {
 
       {/* CTA Button */}
       <div className="absolute left-1/2 transform -translate-x-1/2 bottom-[16%] z-30">
-        <TiltCard
-          href="/event-inquiry"
-          className="group max-h-fit rounded-full bg-black p-2 px-6 shadow-[0_20px_50px_rgba(0,0,0,0.8)] hover:bg-[#D9FF8A]"
-        >
-          <span className="text-xl text-white group-hover:text-black font-body">Book Your Tour</span>
-        </TiltCard>
+        <BookNowButton />
       </div>
     </div>
   );

--- a/src/components/shared/PricingCard.tsx
+++ b/src/components/shared/PricingCard.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { Badge } from "@/components/ui/badge";
-import { Button, ButtonProps } from "@/components/ui/button";
+import { BookNowButton } from "@/components/ui/book-now-button";
 import { Check } from "lucide-react";
 import { cn } from '@/lib/utils';
+import type { ButtonProps } from '@/components/ui/button';
 
 export interface PricingCardProps {
   name: string;
@@ -13,9 +14,8 @@ export interface PricingCardProps {
   features: string[];
   description?: string;
   preFeaturesContent?: React.ReactNode; // For content like 'Seasons'
-  buttonText: string;
-  buttonIcon?: React.ReactNode;
-  buttonProps?: Omit<ButtonProps, 'children'>; // Pass other button props like variant, onClick, etc.
+  // CTA handled via BookNowButton
+  buttonProps?: Omit<ButtonProps, 'children'>;
   cardClassName?: string;
   badgeClassName?: string;
 }
@@ -29,9 +29,6 @@ const PricingCard: React.FC<PricingCardProps> = ({
   features,
   description,
   preFeaturesContent,
-  buttonText,
-  buttonIcon,
-  buttonProps = {},
   cardClassName,
   badgeClassName,
 }) => {
@@ -66,9 +63,7 @@ const PricingCard: React.FC<PricingCardProps> = ({
           ))}
         </ul>
 
-        <Button className="w-full gap-2" {...buttonProps}>
-          {buttonText} {buttonIcon}
-        </Button>
+        <BookNowButton className="w-full" />
       </div>
     </div>
   );

--- a/src/components/showers/ShowersCTA.tsx
+++ b/src/components/showers/ShowersCTA.tsx
@@ -1,7 +1,6 @@
 
-import { ArrowRight, CalendarCheck } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
+import { BookNowButton } from "@/components/ui/book-now-button";
 
 function ShowersCTA() {
   return (
@@ -20,17 +19,8 @@ function ShowersCTA() {
               Our calendar is filling up quickly for the upcoming season.
             </p>
           </div>
-          <div className="flex flex-row gap-4">
-            <Button className="gap-4" asChild>
-              <a href="/event-inquiry">
-                Reserve Your Date <ArrowRight className="w-4 h-4" />
-              </a>
-            </Button>
-            <Button variant="outline" className="gap-4" asChild>
-              <a href="/contact">
-                Schedule a Tour <CalendarCheck className="w-4 h-4" />
-              </a>
-            </Button>
+          <div>
+            <BookNowButton />
           </div>
         </div>
       </div>

--- a/src/components/showers/ShowersHero.tsx
+++ b/src/components/showers/ShowersHero.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import HeroSection from '@/components/shared/HeroSection'; // Import the shared component
-import { TiltCard } from '@/components/ui/tilt-card';
+import { BookNowButton } from '@/components/ui/book-now-button';
 
 const ShowersHero = () => {
   const heroImages = [
@@ -26,9 +26,7 @@ const ShowersHero = () => {
 
       {/* CTA TiltCard Button */}
       <div className="absolute left-1/2 transform -translate-x-1/2 bottom-[16%] z-30">
-        <TiltCard href="/event-inquiry" className="group max-h-fit rounded-full bg-black p-2 px-6 shadow-[0_20px_50px_rgba(0,0,0,0.8)] hover:bg-[#D9FF8A]">
-          <span className="text-xl text-white group-hover:text-black font-body">Book Your Tour</span>
-        </TiltCard>
+        <BookNowButton />
       </div>
     </div>
   );

--- a/src/components/showers/ShowersPackages.tsx
+++ b/src/components/showers/ShowersPackages.tsx
@@ -21,7 +21,6 @@ const ShowersPackages = () => {
         "Tables and chairs included",
         "On-site coordinator"
       ],
-      buttonText: "Choose Essential",
       buttonProps: { variant: "outline", className: "font-body" },
       popular: false, // Use 'popular' prop, map 'highlighted' to it
       cardClassName: "font-body", // Apply font-body to card if needed, or adjust PricingCard
@@ -41,7 +40,6 @@ const ShowersPackages = () => {
         "Beverage station setup",
         "Photo backdrop area"
       ],
-      buttonText: "Choose Premium",
       buttonProps: { variant: "default", className: "font-body" },
       popular: true, // Map 'highlighted' to 'popular'
       popularText: "Most Popular", // Or keep original badge text if different
@@ -63,7 +61,6 @@ const ShowersPackages = () => {
         "Photo booth with props",
         "Floral centerpieces"
       ],
-      buttonText: "Choose Luxe",
       buttonProps: { variant: "outline", className: "font-body" },
       popular: false,
       cardClassName: "font-body",

--- a/src/components/ui/book-now-button.tsx
+++ b/src/components/ui/book-now-button.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { TiltCard } from '@/components/ui/tilt-card';
+import { cn } from '@/lib/utils';
+
+interface BookNowButtonProps extends React.HTMLAttributes<HTMLDivElement> {
+  href?: string;
+}
+
+export function BookNowButton({ href = '/event-inquiry', className, ...props }: BookNowButtonProps) {
+  return (
+    <TiltCard
+      href={href}
+      className={cn(
+        'group max-h-fit rounded-full bg-black p-2 px-6 shadow-[0_20px_50px_rgba(0,0,0,0.8)] hover:bg-[#D9FF8A]',
+        className
+      )}
+      {...props}
+    >
+      <span className="text-xl text-white group-hover:text-black font-body">Book now</span>
+    </TiltCard>
+  );
+}

--- a/src/components/ui/call-to-action/component.tsx
+++ b/src/components/ui/call-to-action/component.tsx
@@ -1,6 +1,5 @@
-import { CalendarCheck, ArrowRight } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
+import { BookNowButton } from "@/components/ui/book-now-button";
 
 function CTA() {
   return <div className="w-full py-10 lg:py-[40px]">
@@ -19,17 +18,8 @@ function CTA() {
               for weddings, showers, and corporate events.
             </p>
           </div>
-          <div className="flex flex-row gap-4">
-            <Button className="gap-4" asChild>
-              <a href="/contact">
-                Schedule a Tour <CalendarCheck className="w-4 h-4" />
-              </a>
-            </Button>
-            <Button variant="outline" className="gap-4" asChild>
-              <a href="/event-inquiry">
-                Get Custom Quote <ArrowRight className="w-4 h-4" />
-              </a>
-            </Button>
+          <div>
+            <BookNowButton />
           </div>
         </div>
       </div>

--- a/src/components/ui/featured-quote.tsx
+++ b/src/components/ui/featured-quote.tsx
@@ -33,7 +33,7 @@ const FeaturedQuote = () => {
               transition={{ duration: 0.8, delay: 0.4 }}
               viewport={{ once: true }}
             >
-              <cite className="not-italic">-Big Tony & Little Tony</cite>
+              <cite className="not-italic">-Tony</cite>
             </motion.div>
           </div>
         </motion.div>

--- a/src/components/wedding/WeddingCTA.tsx
+++ b/src/components/wedding/WeddingCTA.tsx
@@ -1,7 +1,6 @@
 
-import { ArrowRight, CalendarCheck } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
+import { BookNowButton } from "@/components/ui/book-now-button";
 
 function WeddingCTA() {
   return (
@@ -20,17 +19,8 @@ function WeddingCTA() {
               Our calendar is filling up quickly for the upcoming season.
             </p>
           </div>
-          <div className="flex flex-row gap-4">
-            <Button className="gap-4" asChild>
-              <a href="/event-inquiry">
-                Reserve Your Wedding Date <ArrowRight className="w-4 h-4" />
-              </a>
-            </Button>
-            <Button variant="outline" className="gap-4" asChild>
-              <a href="/contact">
-                Schedule a Tour <CalendarCheck className="w-4 h-4" />
-              </a>
-            </Button>
+          <div>
+            <BookNowButton />
           </div>
         </div>
       </div>

--- a/src/components/wedding/WeddingHero.tsx
+++ b/src/components/wedding/WeddingHero.tsx
@@ -1,7 +1,7 @@
 
 import React from 'react';
 import HeroSection from '@/components/shared/HeroSection'; // Import the shared component
-import { CalendarCheck, ArrowRight } from "lucide-react"; // Keep icon imports
+import { BookNowButton } from '@/components/ui/book-now-button';
 
 const WeddingHero = () => {
   const heroImages = [
@@ -11,33 +11,21 @@ const WeddingHero = () => {
     { src: '/photo/haus-party.png', alt: 'Party at Somerhaus' }
   ];
 
-  const buttons = [
-    {
-      text: "Schedule a Tour",
-      icon: <CalendarCheck className="w-5 h-5" />,
-      size: "lg" as const, // Ensure size is correctly typed
-      // href: "/schedule-tour" // Example if it were a link
-    },
-    {
-      text: "Get Your Custom Quote",
-      icon: <ArrowRight className="w-5 h-5" />,
-      size: "lg" as const,
-      variant: "outline" as const, // Ensure variant is correctly typed
-      className: "bg-white/10 backdrop-blur-sm border-white/30 text-white hover:bg-white/20 hover:text-white", // Maintain specific styling
-      // href: "/custom-quote" // Example if it were a link
-    }
-  ];
+  // Buttons handled separately with BookNowButton
 
   return (
-    <HeroSection
-      backgroundType="carousel"
-      backgroundSources={heroImages}
-      title="Where Cincinnati Love Stories Begin"
-      subtitle="Tour our 3,080 sq ft industrial-chic venue and discover the perfect backdrop for your dream wedding."
-      buttons={buttons}
-      // Default class names and carousel options in HeroSection match the original component
-      // Add contentContainerClassName="animate-fade-in" if animation is desired
-    />
+    <div className="relative">
+      <HeroSection
+        backgroundType="carousel"
+        backgroundSources={heroImages}
+        title="Where Cincinnati Love Stories Begin"
+        subtitle="Tour our 3,080 sq ft industrial-chic venue and discover the perfect backdrop for your dream wedding."
+        buttons={[]}
+      />
+      <div className="absolute left-1/2 transform -translate-x-1/2 bottom-[16%] z-30">
+        <BookNowButton />
+      </div>
+    </div>
   );
 };
 

--- a/src/components/wedding/WeddingPackages.tsx
+++ b/src/components/wedding/WeddingPackages.tsx
@@ -27,7 +27,6 @@ const WeddingPackages = () => {
           <span>January, February, March, November</span>
         </div>
       ),
-      buttonText: "Check Available Dates",
       buttonIcon: <ArrowRight className="w-4 h-4" />,
     },
     {
@@ -51,7 +50,6 @@ const WeddingPackages = () => {
           <span>April through October, December</span>
         </div>
       ),
-      buttonText: "Check Available Dates",
       buttonIcon: <ArrowRight className="w-4 h-4" />,
     }
   ];

--- a/src/pages/BarPackages.tsx
+++ b/src/pages/BarPackages.tsx
@@ -36,7 +36,6 @@ const BarPackages = () => {
                 'Soft drinks, mixers & garnishes',
                 '3 hours of service (add hrs $9/guest)' ,
               ],
-              buttonText: 'Book Tier 1',
               buttonProps: { } ,
             },
             {
@@ -49,7 +48,6 @@ const BarPackages = () => {
                 'Soft drinks, mixers & garnishes',
                 '3 hours of service (add hrs $7/guest)',
               ],
-              buttonText: 'Book Tier 2',
               buttonProps: { variant: 'outline' },
             },
             {
@@ -61,7 +59,6 @@ const BarPackages = () => {
                 'Soft drinks included',
                 '3 hours of service (add hrs $7/guest)',
               ],
-              buttonText: 'Book Tier 3',
               buttonProps: { variant: 'outline' },
             },
           ]}

--- a/src/pages/Dinners.tsx
+++ b/src/pages/Dinners.tsx
@@ -42,7 +42,6 @@ const Dinners = () => {
         "Bar setup included"
       ],
       popular: false,
-      buttonText: "Book This Package"
     },
     {
       name: "Elegant Dinner",
@@ -61,7 +60,6 @@ const Dinners = () => {
         "Photography coordination"
       ],
       popular: true,
-      buttonText: "Book This Package"
     },
     {
       name: "Grand Dinner Event",
@@ -81,7 +79,6 @@ const Dinners = () => {
         "Custom menu planning support"
       ],
       popular: false,
-      buttonText: "Book This Package"
     }
   ];
 

--- a/src/pages/HappyHours.tsx
+++ b/src/pages/HappyHours.tsx
@@ -121,7 +121,6 @@ const HappyHours = () => {
         "Event coordination"
       ],
       popular: false,
-      buttonText: "Book This Package"
     },
     {
       name: "Premium Happy Hour",
@@ -140,7 +139,6 @@ const HappyHours = () => {
         "Event management"
       ],
       popular: true,
-      buttonText: "Book This Package"
     },
     {
       name: "Corporate Celebration",
@@ -160,7 +158,6 @@ const HappyHours = () => {
         "Photography coordination"
       ],
       popular: false,
-      buttonText: "Book This Package"
     }
   ];
 

--- a/src/pages/Meetings.tsx
+++ b/src/pages/Meetings.tsx
@@ -122,7 +122,6 @@ const Meetings = () => {
         "Meeting coordination"
       ],
       popular: false,
-      buttonText: "Book This Package"
     },
     {
       name: "Board Meeting",
@@ -142,7 +141,6 @@ const Meetings = () => {
         "Private breakout spaces"
       ],
       popular: true,
-      buttonText: "Book This Package"
     },
     {
       name: "Corporate Summit",
@@ -163,7 +161,6 @@ const Meetings = () => {
         "Executive hospitality suite"
       ],
       popular: false,
-      buttonText: "Book This Package"
     }
   ];
 

--- a/src/pages/Parties.tsx
+++ b/src/pages/Parties.tsx
@@ -43,7 +43,6 @@ const Parties = () => {
         "Event coordination"
       ],
       popular: false,
-      buttonText: "Book This Package"
     },
     {
       name: "Celebration Party",
@@ -63,7 +62,6 @@ const Parties = () => {
         "Welcome cocktail service"
       ],
       popular: true,
-      buttonText: "Book This Package"
     },
     {
       name: "Grand Celebration",
@@ -84,7 +82,6 @@ const Parties = () => {
         "Late night service"
       ],
       popular: false,
-      buttonText: "Book This Package"
     }
   ];
 

--- a/src/pages/Rehearsals.tsx
+++ b/src/pages/Rehearsals.tsx
@@ -43,7 +43,6 @@ const Rehearsals = () => {
         "Bridal suite access"
       ],
       popular: false,
-      buttonText: "Book This Package"
     },
     {
       name: "Complete Rehearsal",
@@ -62,7 +61,6 @@ const Rehearsals = () => {
         "Dedicated event coordinator"
       ],
       popular: true,
-      buttonText: "Book This Package"
     },
     {
       name: "Premium Rehearsal Event",
@@ -82,7 +80,6 @@ const Rehearsals = () => {
         "Welcome cocktail service"
       ],
       popular: false,
-      buttonText: "Book This Package"
     }
   ];
 

--- a/src/pages/SpecialEvents.tsx
+++ b/src/pages/SpecialEvents.tsx
@@ -41,7 +41,6 @@ const SpecialEvents = () => {
         "Event coordination"
       ],
       popular: false,
-      buttonText: "Book This Package"
     },
     {
       name: "Celebration Package",
@@ -59,7 +58,6 @@ const SpecialEvents = () => {
         "Vendor coordination"
       ],
       popular: true,
-      buttonText: "Book This Package"
     },
     {
       name: "Grand Celebration",
@@ -78,7 +76,6 @@ const SpecialEvents = () => {
         "Day-of event management"
       ],
       popular: false,
-      buttonText: "Book This Package"
     }
   ];
 


### PR DESCRIPTION
## Summary
- add `BookNowButton` shared component
- remove limited-dates text from homepage hero and switch hero buttons to use BookNowButton
- unify booking CTA components across the site
- update quote attribution
- refactor pricing card and remove package-specific button text

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685190856c908321ad3ad7c42c38ec77