### PR TITLE
Standardize hero and section heading styles

### DIFF
--- a/src/components/shared/HeroSection.tsx
+++ b/src/components/shared/HeroSection.tsx
@@ -49,7 +49,8 @@ const HeroSection: React.FC<HeroSectionProps> = ({
   buttons = [],
   sectionClassName = "relative w-full h-[90vh] min-h-[600px] overflow-hidden",
   contentContainerClassName = "absolute inset-0 z-20 flex flex-col items-center justify-center text-white text-center px-4",
-  titleClassName = "text-4xl md:text-6xl lg:text-7xl font-header tracking-tight mb-4 text-white",
+  // Match the homepage hero size
+  titleClassName = "text-5xl md:text-6xl font-header tracking-tight mb-4 text-white",
   subtitleClassName = "text-lg md:text-xl max-w-2xl mx-auto mb-8 text-white/90 font-body",
   carouselOptions = { loop: true },
   autoplayOptions = { delay: 4000, stopOnInteraction: false, stopOnMouseEnter: false }

--- a/src/components/vendors/VendorsHero.tsx
+++ b/src/components/vendors/VendorsHero.tsx
@@ -14,7 +14,8 @@ const VendorsHero: React.FC = () => {
 
       {/* Content */}
       <div className="relative z-10 flex flex-col items-center justify-center h-full text-center text-white px-4">
-        <h1 className="text-4xl md:text-6xl lg:text-7xl font-header tracking-tight mb-4">Preferred Vendors</h1>
+        {/* Use the homepage hero heading size */}
+        <h1 className="text-5xl md:text-6xl font-header tracking-tight mb-4">Preferred Vendors</h1>
         <p className="text-lg md:text-xl max-w-2xl mx-auto font-body text-white/90">
           From photographers to catering, we've curated a trusted list of partners to make your planning effortless.
         </p>

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -102,7 +102,8 @@ const ContactPage = () => {
                     backgroundImage: "url('/photo/space-portrait1-cincinnati-event-space-somerhaus.jpg')"
         }} />
         <div className="relative z-20 container mx-auto px-4 h-full flex flex-col justify-center text-center">
-          <h1 className="text-4xl md:text-6xl lg:text-7xl font-header tracking-tight mb-4 text-white">
+          {/* Use consistent hero heading size */}
+          <h1 className="text-5xl md:text-6xl font-header tracking-tight mb-4 text-white">
             Let's Plan Something Magical Together
           </h1>
           <p className="text-lg md:text-xl max-w-2xl mx-auto mb-8 text-white/90 font-mono">

--- a/src/pages/Gallery.tsx
+++ b/src/pages/Gallery.tsx
@@ -96,7 +96,8 @@ const Gallery = () => {
         <div className="absolute inset-0 bg-black/40" />
         <div className="relative z-10 container mx-auto px-4 text-center text-white">
           <Badge className="mb-4 font-body">Photo Gallery</Badge>
-          <h1 className="text-4xl md:text-6xl lg:text-7xl font-header tracking-tight mb-4">
+          {/* Match homepage hero sizing */}
+          <h1 className="text-5xl md:text-6xl font-header tracking-tight mb-4">
             Photo Gallery
           </h1>
           <p className="text-lg md:text-xl max-w-2xl mx-auto mb-8 text-white/90 font-body">

--- a/src/styles/brand-colors.css
+++ b/src/styles/brand-colors.css
@@ -3,6 +3,18 @@
 /* Apply brand color to all headings by default */
 h1, h2, h3, h4, h5, h6 {
   color: #ea580c !important;
+  font-family: 'FreshMango', serif;
+  font-weight: 700;
+}
+
+/* Consistent section heading sizes */
+h2 {
+  font-size: 3rem;
+  line-height: 1;
+}
+h3 {
+  font-size: 2.25rem;
+  line-height: 1.1;
 }
 
 /* Override for specific cases where headings should remain white */


### PR DESCRIPTION
## Summary
- match hero heading sizes to home page in shared component
- use same hero size on the vendors, gallery and contact pages
- define consistent font and sizes for headings globally

## Testing
- `npm run lint` *(fails: 12 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_685190995058832187b32b80c4b5eb61